### PR TITLE
fix: always increment base release, not just for betas (CUR-204)

### DIFF
--- a/semrel.go
+++ b/semrel.go
@@ -4,15 +4,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/Masterminds/semver"
-	"github.com/google/go-github/github"
-	"golang.org/x/oauth2"
 	"log"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/Masterminds/semver"
+	"github.com/google/go-github/github"
+	"golang.org/x/oauth2"
 )
 
 var commitPattern = regexp.MustCompile("^(\\w*)(?:\\((.*)\\))?\\: (.*)$")
@@ -163,9 +164,8 @@ func (repo *Repository) GetLatestRelease(vrange string, prerelease string) (*Rel
 		prereleaseParts := strings.Split(r.Version.Prerelease(), ".")
 
 		if prereleaseParts[0] == prerelease {
-			// If it is a beta release and the last production release is newer
-			// just stop here and go with the last production release version.
-			if prerelease == "beta" && lastRelease != nil && r.Version.LessThan(lastRelease.Version) {
+			// If the last production release is newer just stop here and go with the last production release version.
+			if lastRelease != nil && r.Version.LessThan(lastRelease.Version) {
 				break
 			}
 


### PR DESCRIPTION
Avoids problems with "persistent" prerelease versions, where e.g.
x.y.z-foo.n is actually based on some a.b.c that is MUCH newer, which
happens a lot with squad integration branches.

If this is accepted, should update https://github.com/6RiverSystems/ci_scripts/blob/master/ci_tool.sh#L296 to use the new version